### PR TITLE
feat: allow specification of source directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,21 @@ Add the `cultureamp/backstage-cdk-assets` plugin to your existing CDK build step
 ```yaml
 steps:
 - plugins:
-  - cultureamp/backstage-cdk-assets#v1.0.0:
+  - cultureamp/backstage-cdk-assets#v1.1.0:
   - docker-compose#v3.8.0:
       build: cdk
       config: docker-compose.ci.yml
 ```
 
-By default the plugin assumes your CDK project is at `ops` and will copy Backstage files into a `.backstage` directory within. Configure the destination path with `dest` parameter:
+By default the plugin assumes your CDK project is at `ops` and will copy
+Backstage files into a `.backstage` directory within. Configure the source and
+destination paths with the `source` and `dest` parameters respectively:
 
 ```yaml
 steps:
 - plugins:
-  - cultureamp/backstage-cdk-assets#v1.0.0:
+  - cultureamp/backstage-cdk-assets#v1.1.0:
+      source: asset     # assets copied from ./asset
       dest: ops/cdk     # assets copied into ./ops/cdk/.backstage
   - docker-compose#v3.8.0:
       build: cdk

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -7,12 +7,29 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/shared.bash"
 
 function main(){
+  local source; source="$(plugin_read_config "SOURCE" "./")"
   local dest; dest="$(plugin_read_config "DEST" "./ops")"
-  dest="${dest}/.backstage"
 
-  rm -rf ${dest}
-  mkdir -p ${dest}
-  cp catalog-info*.y*ml ${dest}
+  source="$(cleanPath "${source}")catalog-info*.y*ml"
+  dest="$(cleanPath "${dest}").backstage"
+
+  rm -rf "${dest}"
+  mkdir -p "${dest}"
+  cp "${source}" "${dest}"
+}
+
+function cleanPath() {
+  local dir=$1
+
+  if [[ "${dir}" != ./* ]]; then
+    dir="./${dir}"
+  fi
+
+  if [[ "${dir}" != */ ]]; then
+    dir="${dir}/"
+  fi
+
+  echo "${dir}"
 }
 
 main "$@"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,9 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite-plugins/buildkite-plugin-linter/master/lib/plugin-yaml-schema.yml
 name: Backstage CDK Assets
 description: Copies Backstage catalog-info.yaml files into the CDK application prior to building
 author: https://github.com/cultureamp
 requirements: []
 configuration:
   properties:
+    source:
+      type: string
     dest:
       type: string
   additionalProperties: false

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -22,7 +22,7 @@ teardown_stubs() {
   unstub cp
 }
 
-@test "it copies .yaml files to ops by default" {
+@test "it copies .yaml files from the current directory to ops by default" {
   setup_stubs
 
   run "$PWD/hooks/post-checkout"
@@ -30,7 +30,7 @@ teardown_stubs() {
   assert_success
   assert_line --partial "stubbed rm -rf ./ops/.backstage"
   assert_line --partial "stubbed mkdir -p ./ops/.backstage"
-  assert_line --partial "stubbed cp catalog-info*.y*ml ./ops/.backstage"
+  assert_line --partial "stubbed cp ./catalog-info*.y*ml ./ops/.backstage"
 
   teardown_stubs
 }
@@ -44,7 +44,36 @@ teardown_stubs() {
   assert_success
   assert_line --partial "stubbed rm -rf ./ops/cdk/.backstage"
   assert_line --partial "stubbed mkdir -p ./ops/cdk/.backstage"
-  assert_line --partial "stubbed cp catalog-info*.y*ml ./ops/cdk/.backstage"
+  assert_line --partial "stubbed cp ./catalog-info*.y*ml ./ops/cdk/.backstage"
+
+  teardown_stubs
+}
+
+@test "it copies .yaml files from the provided source directory to the dest directory" {
+  setup_stubs
+  export BUILDKITE_PLUGIN_BACKSTAGE_CDK_ASSETS_SOURCE="./source-dir"
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_line --partial "stubbed rm -rf ./ops/.backstage"
+  assert_line --partial "stubbed mkdir -p ./ops/.backstage"
+  assert_line --partial "stubbed cp ./source-dir/catalog-info*.y*ml ./ops/.backstage"
+
+  teardown_stubs
+}
+
+@test "it handles non-relative source and dest directories" {
+  setup_stubs
+  export BUILDKITE_PLUGIN_BACKSTAGE_CDK_ASSETS_SOURCE="source-dir/"
+  export BUILDKITE_PLUGIN_BACKSTAGE_CDK_ASSETS_DEST="dest-dir/"
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_line --partial "stubbed rm -rf ./dest-dir/.backstage"
+  assert_line --partial "stubbed mkdir -p ./dest-dir/.backstage"
+  assert_line --partial "stubbed cp ./source-dir/catalog-info*.y*ml ./dest-dir/.backstage"
 
   teardown_stubs
 }


### PR DESCRIPTION
Allows the use of the `source` parameter to specify the directory that files are copied from. Useful for some repos where catalog files aren't at the root.