### PR TITLE
fix: shell expansion of args

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the `cultureamp/backstage-cdk-assets` plugin to your existing CDK build step
 ```yaml
 steps:
 - plugins:
-  - cultureamp/backstage-cdk-assets#v1.1.0:
+  - cultureamp/backstage-cdk-assets#v1.1.1:
   - docker-compose#v3.8.0:
       build: cdk
       config: docker-compose.ci.yml
@@ -23,7 +23,7 @@ destination paths with the `source` and `dest` parameters respectively:
 ```yaml
 steps:
 - plugins:
-  - cultureamp/backstage-cdk-assets#v1.1.0:
+  - cultureamp/backstage-cdk-assets#v1.1.1:
       source: asset     # assets copied from ./asset
       dest: ops/cdk     # assets copied into ./ops/cdk/.backstage
   - docker-compose#v3.8.0:

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -15,7 +15,7 @@ function main(){
 
   rm -rf "${dest}"
   mkdir -p "${dest}"
-  cp "${source}" "${dest}"
+  cp ${source} ${dest}
 }
 
 function cleanPath() {


### PR DESCRIPTION
## Purpose 🎯 

Fix for version `v1.1.0`

## Context 🧠 

Recently released `v1.1.0` doesn't expand the `source` pattern to match files and results in this error:

```
❯ cp "./catalog-info*.y*ml" ./ops/.backstage
cp: ./catalog-info*.y*ml: No such file or directory
```

## Release ⏩ 

- [x] To be released as `v1.1.1`